### PR TITLE
WDP190405-6: Add old price styling and sample old prices

### DIFF
--- a/src/partials/50_section-products.html
+++ b/src/partials/50_section-products.html
@@ -102,7 +102,41 @@
               <a href="#" class="btn-outline"><i class="far fa-heart"></i></a>
               <a href="#" class="btn-outline"><i class="fas fa-exchange-alt"></i></a>
             </div>
-            <div class="price"><div class="btn-main-small no-hover">$ 30.00</div></div>
+            <div class="price">
+              <div class="price-old">$ 35.00</div>
+              <div class="btn-main-small no-hover">$ 25.00</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="col-3">
+        <div class="product-box">
+          <div class="photo">
+            <div class="sale">sale</div>
+            <div class="buttons">
+              <a href="#" class="btn-main-small">Quick View</a>
+              <a href="#" class="btn-main-small"
+                ><i class="fa fa-shopping-basket"></i> ADD TO CART</a
+              >
+            </div>
+          </div>
+          <div class="content">
+            <h5>Aenean Ru Bristique</h5>
+            <div class="stars">
+              <a href="#" class="full"></a> <a href="#" class="full"></a>
+              <a href="#"></a> <a href="#"></a> <a href="#"></a>
+            </div>
+          </div>
+          <div class="line"></div>
+          <div class="actions">
+            <div class="outlines">
+              <a href="#" class="btn-outline"><i class="far fa-heart"></i></a>
+              <a href="#" class="btn-outline"><i class="fas fa-exchange-alt"></i></a>
+            </div>
+            <div class="price">
+              <div class="price-old">$ 20.00</div>
+              <div class="btn-main-small no-hover">$ 15.00</div>
+            </div>
           </div>
         </div>
       </div>
@@ -186,7 +220,10 @@
               <a href="#" class="btn-outline"><i class="far fa-heart"></i></a>
               <a href="#" class="btn-outline"><i class="fas fa-exchange-alt"></i></a>
             </div>
-            <div class="price"><div class="btn-main-small no-hover">$ 30.00</div></div>
+            <div class="price">
+              <div class="price-old">$ 40.00</div>
+              <div class="btn-main-small no-hover">$ 30.00</div>
+            </div>
           </div>
         </div>
       </div>
@@ -214,35 +251,10 @@
               <a href="#" class="btn-outline"><i class="far fa-heart"></i></a>
               <a href="#" class="btn-outline"><i class="fas fa-exchange-alt"></i></a>
             </div>
-            <div class="price"><div class="btn-main-small no-hover">$ 30.00</div></div>
-          </div>
-        </div>
-      </div>
-      <div class="col-3">
-        <div class="product-box">
-          <div class="photo">
-            <div class="sale">sale</div>
-            <div class="buttons">
-              <a href="#" class="btn-main-small">Quick View</a>
-              <a href="#" class="btn-main-small"
-                ><i class="fa fa-shopping-basket"></i> ADD TO CART</a
-              >
+            <div class="price">
+              <div class="price-old">$ 35.00</div>
+              <div class="btn-main-small no-hover">$ 30.00</div>
             </div>
-          </div>
-          <div class="content">
-            <h5>Aenean Ru Bristique</h5>
-            <div class="stars">
-              <a href="#" class="full"></a> <a href="#" class="full"></a>
-              <a href="#"></a> <a href="#"></a> <a href="#"></a>
-            </div>
-          </div>
-          <div class="line"></div>
-          <div class="actions">
-            <div class="outlines">
-              <a href="#" class="btn-outline"><i class="far fa-heart"></i></a>
-              <a href="#" class="btn-outline"><i class="fas fa-exchange-alt"></i></a>
-            </div>
-            <div class="price"><div class="btn-main-small no-hover">$ 30.00</div></div>
           </div>
         </div>
       </div>

--- a/src/sass/components/_button.scss
+++ b/src/sass/components/_button.scss
@@ -19,6 +19,7 @@
   line-height: 24px;
   padding: 5px 10px;
   font-weight: 400;
+  display: inline-block;
 }
 
 .btn-outline {

--- a/src/sass/components/_product-box.scss
+++ b/src/sass/components/_product-box.scss
@@ -79,6 +79,25 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+
+    .price {
+      .price-old {
+        display: inline-block;
+        position: relative;
+        font-size: 13px;
+        line-height: 22px;
+        font-weight: 300;
+        color: darkgray;
+
+        &:before {
+          position: absolute;
+          content: "";
+          border-bottom: 1px solid $text-color;
+          width: 100%;
+          height: 50%;
+        }
+      }
+    }
   }
 
   &:hover {


### PR DESCRIPTION
Na kartach kilku produktów dodałem przykładowe stare ceny i ostylowałem je zgodnie z projektem. Stare ceny dodałem w divie-rodzicu (.price) obok obecnej ceny.
Dodałem "display: inline-block" do obecnej ceny (.btn-main-small).